### PR TITLE
SSL cert is invalid, Chage: https -> http

### DIFF
--- a/src/main/scala/edu/stanford/graphics/shapenet/Constants.scala
+++ b/src/main/scala/edu/stanford/graphics/shapenet/Constants.scala
@@ -30,7 +30,7 @@ trait Constants {
   val WEB_CACHE_DIR = CACHE_DIR + "web" + File.separator
 
   val SHAPENET_VIEWER_DIR = ensureDir(prop("SHAPENET_VIEWER_DIR", CODE_DIR + "shapenet-viewer"))
-  val SHAPENET_HOST = prop("SHAPENET_HOST", "https://www.shapenet.org")
+  val SHAPENET_HOST = prop("SHAPENET_HOST", "http://www.shapenet.org")
   val ASSETS_DIR = ensureDir(prop("ASSETS_DIR", SHAPENET_VIEWER_DIR + "/assets"))
   val MISC_DATA_HOST = prop("DATA_HOST", "http://dovahkiin.stanford.edu")
   val TEXT2SCENE_DIR = if (USE_LOCAL_DATA) DATA_DIR + "text2scene" + separator else MISC_DATA_HOST + "/text2scene/"


### PR DESCRIPTION
Currently the SSL cert expired on shapenet.org, this circumvents that issue. Work around until cert is updated.


![Screenshot from 2019-05-21 20-16-08](https://user-images.githubusercontent.com/5906193/58138676-5557aa00-7c05-11e9-99bb-5e74a73889f2.png)
